### PR TITLE
fix: sync server version with package.json

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@ import { RateLimiter } from "./middleware/rate-limiter.js";
 import { registerAllTools } from "./tools/index.js";
 import { ErrorCode, McpError } from "./utils/error-codes.js";
 import { logger } from "./utils/logger.js";
+import { VERSION } from "./utils/version.js";
 
 /**
  * Graceful shutdown handler
@@ -162,7 +163,7 @@ async function main() {
 		// Initialize the MCP server
 		const server = new McpServer({
 			name: "spec-mcp",
-			version: "0.1.0",
+			version: VERSION,
 		});
 
 		// Initialize spec operations
@@ -199,7 +200,7 @@ async function main() {
 		logger.info(
 			{
 				specsPath: config.specsPath,
-				version: "0.1.0",
+				version: VERSION,
 			},
 			"Spec MCP Server running",
 		);

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import pino from "pino";
+import { VERSION } from "./version.js";
 
 /**
  * Logger instance for the MCP server
@@ -8,7 +9,7 @@ const pinoOptions: Record<string, unknown> = {
 	level: process.env.LOG_LEVEL || "info",
 	base: {
 		service: "spec-mcp",
-		version: "0.1.0",
+		version: VERSION,
 	},
 };
 

--- a/packages/server/src/utils/version.ts
+++ b/packages/server/src/utils/version.ts
@@ -1,0 +1,10 @@
+// Import version directly from package.json
+// TypeScript's resolveJsonModule allows this import
+// When bundled with tsup, the version string will be inlined
+import packageJson from "../../package.json" assert { type: "json" };
+
+/**
+ * Version string from package.json
+ * This ensures the version is always in sync with the package.json
+ */
+export const VERSION = packageJson.version;

--- a/packages/server/src/utils/version.ts
+++ b/packages/server/src/utils/version.ts
@@ -1,7 +1,7 @@
 // Import version directly from package.json
 // TypeScript's resolveJsonModule allows this import
 // When bundled with tsup, the version string will be inlined
-import packageJson from "../../package.json" assert { type: "json" };
+import packageJson from "../../package.json" with { type: "json" };
 
 /**
  * Version string from package.json


### PR DESCRIPTION
## Summary

Fixed the version mismatch between `package.json` and console output.

## Changes

- Created `utils/version.ts` to dynamically import version from package.json
- Updated McpServer initialization to use VERSION constant
- Updated logger configuration to use VERSION constant
- Updated server running log to use VERSION constant

Closes #11

---

Generated with [Claude Code](https://claude.ai/code)