### PR TITLE
fix: add yaml dependency to @spec-mcp/server package

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,7 +30,8 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.18.2",
-		"pino": "^9.12.0"
+		"pino": "^9.12.0",
+		"yaml": "^2.4.5"
 	},
 	"devDependencies": {
 		"@spec-mcp/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       pino:
         specifier: ^9.12.0
         version: 9.12.0
+      yaml:
+        specifier: ^2.4.5
+        version: 2.8.1
     devDependencies:
       '@spec-mcp/core':
         specifier: workspace:*


### PR DESCRIPTION
The yaml package is used by @spec-mcp/utils which is bundled with the server when published. The yaml dependency needs to be explicitly declared in the server's dependencies to be available when installed via npx.

Fixes #19

Generated with [Claude Code](https://claude.ai/code)